### PR TITLE
Adds a Zammad form to the contact page

### DIFF
--- a/assets/sass/contact.scss
+++ b/assets/sass/contact.scss
@@ -1,3 +1,0 @@
-.zammad-form .btn {
-	cursor: pointer;
-}

--- a/assets/sass/contact.scss
+++ b/assets/sass/contact.scss
@@ -1,0 +1,3 @@
+.zammad-form .btn {
+	cursor: pointer;
+}

--- a/assets/sass/form.scss
+++ b/assets/sass/form.scss
@@ -1,0 +1,48 @@
+input[type="text"], input[type="email"], textarea {
+	box-sizing: border-box;
+	border:1px solid black;
+	border-radius: $radius;
+	&:focus {
+		border:3px solid $clr_A;
+		padding:18px;
+	}
+	padding:20px;
+}
+
+.button, .zammad-form .btn {
+	cursor: pointer;
+	background-color: $clr_C;
+	border:none;
+	border-radius: $radius;
+	padding:10px;
+	&:hover {
+		background-color: $clr_C_dark;
+	}
+}
+
+
+.zammad-form {
+	margin-bottom:5rem;
+}
+
+.zammad-form .btn {
+	margin-top:1.5rem;
+}
+
+.zammad-form label {
+	font-weight: bold;
+	font-size: calc( 1.4rem + 0.5vw);
+	display: block;
+	margin-bottom: 1rem;
+}
+
+.zammad-form input {
+	margin-bottom: 1rem;
+}
+
+.zammad-form .js-thankyou {
+	padding:2rem;
+	background-color: $clr_B;
+	margin-top:5rem;
+	margin-bottom: 5rem;
+}

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -479,27 +479,6 @@ p a {
 	text-align: center;
 }
 
-input[type="text"], input[type="email"], textarea {
-	box-sizing: border-box;
-	border:1px solid black;
-	border-radius: $radius;
-	&:focus {
-		border:3px solid $clr_A;
-		padding:8px;
-	}
-	padding:10px;
-}
-
-.button, .zammad-form .btn {
-	background-color: $clr_C;
-	border:none;
-	border-radius: $radius;
-	padding:10px;
-	&:hover {
-		background-color: $clr_C_dark;
-	}
-}
-
 .social {
 	display: flex;
 	justify-content: center;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -116,11 +116,11 @@ p a {
 
 .topbar {
 	@include gridrow;
-	grid-template-areas: 
+	grid-template-areas:
     "ticker ticker ticker ticker secnav secnav secnav secnav secnav secnav secnav secnav";
 	//position: fixed;
 	@media screen and (max-width:$breakpoint2b) {
-		grid-template-areas: 
+		grid-template-areas:
 		"ticker ticker ticker ticker ticker ticker ticker ticker ticker ticker ticker ticker";
 		text-align: center;
 	}
@@ -151,14 +151,14 @@ p a {
 .logobar {
 	@include gridrow;
 	grid-template-rows: 33.333% 33.333% 33.333%;
-	grid-template-areas: 
+	grid-template-areas:
 	"lg lg bg bg bg bg bg bg bg bg bg bg"
 	"lbg lbg lbg lbg lbg lbg lbg lbg lbg lbg lbg lbg"
 	"bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg";
 
 
 	@media screen and (max-width:$breakpoint1) {
-		grid-template-areas: 
+		grid-template-areas:
 		"lg lg lg bg bg bg bg bg bg bg bg bg"
 		"lg lg lg lbg lbg lbg lbg lbg lbg lbg lbg lbg"
 		"bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg";
@@ -166,7 +166,7 @@ p a {
 
 
 	@media screen and (max-width:$breakpoint3) {
-		grid-template-areas: 
+		grid-template-areas:
 		"lg lg lg lg lg bg bg bg bg bg bg bg"
 		"lg lg lg lg lg lbg lbg lbg lbg lbg lbg lbg"
 		"bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg bbg";
@@ -233,7 +233,7 @@ p a {
 	padding-right:calc(0.8rem + 0.8vw);
 	padding-left:calc(0.8rem + 0.8vw);
 	font-size: calc(0.8rem + 0.8vw) ;
-	@media screen and (max-width:$breakpoint3) { 
+	@media screen and (max-width:$breakpoint3) {
 		padding-top:0;
 		font-size: calc(1rem + 0.6vw) ;
 	}
@@ -351,16 +351,16 @@ p a {
 	font-weight: 400;
 	font-size:2rem ;
 
-	@media screen and (max-width:$breakpoint0) {	
+	@media screen and (max-width:$breakpoint0) {
 		font-size:1.6rem ;
 		padding-right:$spacer;
 		padding-left:$spacer;
 	}
-	@media screen and (max-width:$breakpoint1) {	
+	@media screen and (max-width:$breakpoint1) {
 		font-size:1.4rem ;
 	}
 	text-decoration: none;
-	@media screen and (max-width:$breakpoint_primnav) {		
+	@media screen and (max-width:$breakpoint_primnav) {
 		padding-right:$spacer;
 		padding-left:$spacer;
 	}
@@ -431,7 +431,7 @@ p a {
 	@media screen and (min-width:$breakpoint2) {
 		grid-column: 4 / span 6;
 	}
-	text-align: center;	
+	text-align: center;
 	padding: $spacer*2;
 	padding-top: $spacer;
 	padding-bottom: $spacer;
@@ -479,7 +479,7 @@ p a {
 	text-align: center;
 }
 
-input[type="text"], input[type="email"] {
+input[type="text"], input[type="email"], textarea {
 	box-sizing: border-box;
 	border:1px solid black;
 	border-radius: $radius;
@@ -490,7 +490,7 @@ input[type="text"], input[type="email"] {
 	padding:10px;
 }
 
-.button {
+.button, .zammad-form .btn {
 	background-color: $clr_C;
 	border:none;
 	border-radius: $radius;

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -4,4 +4,5 @@
 @import 'gallery.scss';
 @import 'content.scss';
 @import 'mailchimp.scss';
+@import 'contact.scss';
 @import 'testcode.scss';

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -4,5 +4,5 @@
 @import 'gallery.scss';
 @import 'content.scss';
 @import 'mailchimp.scss';
-@import 'contact.scss';
+@import 'form.scss';
 @import 'testcode.scss';

--- a/content/_index.md
+++ b/content/_index.md
@@ -21,13 +21,3 @@ title: "Welkom!"
 <div class="block--centered">
 {{< social >}}
 </div>
-
-<!-- <div class="block--centered">
-<ul>
-	<li>Foto's</li>
-	<li>Korte geschiedenis</li>
-	<li>Korte 'wat is'</li>
-	<li>Mailinglist</li>
-	<li>Social media</li>
-</ul>
-</div> -->

--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -2,22 +2,20 @@
 title: "Contact"
 layout: "contact"
 ---
-<div class="block--centered">
-
-<p>Als je rechtstreeks contact wil met de organisatie, stuur dan een mailtje naar <a href="mailto:info@fri3d.be">info@fri3d.be</a>.</p>
-
-<!-- <ul>
-	<li>Info vzw</li>
-	<li>Overzicht core orga leden</li>
-	<li>Contact form</li>
-</ul> -->
-</div>
 
 <div class="block--centered">
 {{< contactform >}}
 </div>
 
+<div class="block--centered">
+<p>Je kan ook mailen naar <a href="mailto:info@fri3d.be">info@fri3d.be</a>.</p>
+</div>
+
+<div class="block--centered">
+	{{< vzw >}}
+</div>
 <hr class="gridrule" />
+
 
 <div class="block--centered">
 {{< mailinglist >}}

--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Contact"
-layout: "single"
+layout: "contact"
 ---
 <div class="block--centered">
 

--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -13,6 +13,10 @@ layout: "single"
 </ul> -->
 </div>
 
+<div class="block--centered">
+{{< contactform >}}
+</div>
+
 <hr class="gridrule" />
 
 <div class="block--centered">

--- a/content/wat/_index.md
+++ b/content/wat/_index.md
@@ -13,12 +13,5 @@ layout: "single"
 </div>
 <hr class="gridrule" />
 <div class="block--centered">
-	<address class="orgacontact">
-		<p>
-		Fri3d VZW<br/>
-		Grote Hondstraat 44 - APE Collective<br/>
-		2018 Antwerpen<br/>
-		BTW BE 0734.464.006
-		</p>
-	</address>
+	{{< vzw >}}
 </div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,7 +28,7 @@
 					<a href="/contact/">contact</a> <a href="/privacy/">privacy</a> <a href="/sponsors/">sponsors</a>
 				</nav>
 				</div>
-				
+
 				<div class="logobar">
 					<a class="mainlogo" href="/">
 						<span class="visually-hidden">Fri3d Camp</span>
@@ -39,8 +39,8 @@
 						<a href="/" class="sitenav__homelink"><span class="visually-hidden">Home</span></a>
 						<a href="#primarynav" class="js_opennav vis--small sitenav__hamburger"><span class="visually-hidden">Menu</span></a>
 						<div class="js_navmenu menuitems hideonsmall">
-							<a href="/tickets/">Tickets</a> 
-							<a href="/deelnemers/">Voor deelnemers</a> 
+							<a href="/tickets/">Tickets</a>
+							<a href="/deelnemers/">Voor deelnemers</a>
 							<a href="/wat" >Over Fri3d Camp</a>
 						</div>
 					</nav>
@@ -67,5 +67,7 @@
 		<script src="/js/jquery-3.4.1.min.js" ></script>
 		<script src="/js/gallery.js" ></script>
 		<script src="/js/nav.js" ></script>
+		{{ block "footer_scripts" .}}
+		{{ end }}
 	</body>
 </html>

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+	<div class="maincontent"> {{ .Content }}</div>
+{{ end }}
+
+{{ define "footer_scripts" }}
+	<script id="zammad_form_script" src="https://zammad.fri3d.be/assets/form/form.js"></script>
+{{ end }}

--- a/layouts/shortcodes/contactform.html
+++ b/layouts/shortcodes/contactform.html
@@ -1,0 +1,25 @@
+<h2 class="block__ttl">Contactformulier</h2>
+<p>Vul onderstaand formulier in om contact met ons op te nemen.</p>
+<section class="contactform">
+	<div id="contactForm"></div>
+</section>
+
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
+<script>
+	document.addEventListener('DOMContentLoaded', function() {
+		var zammadScript = document.createElement('script');
+		zammadScript.id = 'zammad_form_script';
+		zammadScript.onload = function () {
+			$('#contactForm').ZammadForm({
+				messageTitle: 'Feedback Form',
+				messageSubmit: 'Submit',
+				messageThankYou: 'Thank you for your inquiry (#%s)! We\'ll contact you as soon as possible.',
+				debug: false,
+				modal: false
+			});
+		};
+
+		zammadScript.src = 'https://zammad.fri3d.be/assets/form/form.js';
+		document.head.appendChild(zammadScript);
+	});
+</script>

--- a/layouts/shortcodes/contactform.html
+++ b/layouts/shortcodes/contactform.html
@@ -4,22 +4,14 @@
 	<div id="contactForm"></div>
 </section>
 
-<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
 <script>
 	document.addEventListener('DOMContentLoaded', function() {
-		var zammadScript = document.createElement('script');
-		zammadScript.id = 'zammad_form_script';
-		zammadScript.onload = function () {
-			$('#contactForm').ZammadForm({
-				messageTitle: 'Feedback Form',
-				messageSubmit: 'Submit',
-				messageThankYou: 'Thank you for your inquiry (#%s)! We\'ll contact you as soon as possible.',
-				debug: false,
-				modal: false
-			});
-		};
-
-		zammadScript.src = 'https://zammad.fri3d.be/assets/form/form.js';
-		document.head.appendChild(zammadScript);
+      $('#contactForm').ZammadForm({
+        messageTitle: 'Feedback Form',
+        messageSubmit: 'Submit',
+        messageThankYou: 'Thank you for your inquiry (#%s)! We\'ll contact you as soon as possible.',
+        debug: false,
+        modal: false
+      });
 	});
 </script>

--- a/layouts/shortcodes/contactform.html
+++ b/layouts/shortcodes/contactform.html
@@ -1,5 +1,4 @@
 <h2 class="block__ttl">Contactformulier</h2>
-<p>Vul onderstaand formulier in om contact met ons op te nemen.</p>
 <section class="contactform">
 	<div id="contactForm"></div>
 </section>
@@ -7,9 +6,9 @@
 <script>
 	document.addEventListener('DOMContentLoaded', function() {
       $('#contactForm').ZammadForm({
-        messageTitle: 'Feedback Form',
-        messageSubmit: 'Submit',
-        messageThankYou: 'Thank you for your inquiry (#%s)! We\'ll contact you as soon as possible.',
+        messageTitle: 'Contactformulier',
+        messageSubmit: 'Versturen',
+        messageThankYou: 'Bedankt voor je vraag (#%s)! Je hoort spoedig van ons.',
         debug: false,
         modal: false
       });

--- a/layouts/shortcodes/vzw.html
+++ b/layouts/shortcodes/vzw.html
@@ -1,0 +1,8 @@
+<address class="orgacontact">
+	<p>
+	Fri3d VZW<br/>
+	Grote Hondstraat 44 - APE Collective<br/>
+	2018 Antwerpen<br/>
+	BTW BE 0734.464.006
+	</p>
+</address>


### PR DESCRIPTION
Second commit fixes CORS issues. I added a way to append scripts to the footer, so the Zammad script doesn't have to be loaded using JS, like before.

Currently uses a layout to override a block (layouts/_default/contact.html), but it might also be possible to move this to a parameter in contact/_index.md's header in the future.